### PR TITLE
Removed icon field, updated version

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
 	"name": "vscode-hydrate",
-	"version": "0.0.1",
+	"version": "1.0.0",
 	"lockfileVersion": 1,
 	"requires": true,
 	"dependencies": {

--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
 	"description": "Hydrate for VSCode Kubernetes Tools",
 	"license": "MIT",
 	"publisher": "madelineliao",
-	"version": "0.0.1",
+	"version": "1.0.0",
 	"repository": {
 		"type": "git",
 		"url": "https://github.com/microsoft/vscode-hydrate.git"

--- a/package.json
+++ b/package.json
@@ -22,7 +22,6 @@
 		"kubernetes",
 		"k8s"
 	],
-	"icon": "icon.png",
 	"preview": true,
 	"activationEvents": [
 		"onView:extension.vsKubernetesExplorer",


### PR DESCRIPTION
A couple of small edits to the `package.json` to prepare for publishing on VSCode.

- Removed icon field since Hydrate doesn't have an icon yet
- Updated the version to 1.0.0).