### PR TITLE
Updated README and VSCode version dependency

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,14 +3,14 @@
 ## Overview
 This is the Visual Studio Code Hydrate extension, which builds upon the [VSCode Kubernetes Extension](https://github.com/Azure/vscode-kubernetes-tools). It allows developers to use [Hydrate](https://github.com/microsoft/hydrate) within VSCode, which crawls a Kubernetes cluster and generates a high level description in a `component.yaml` file for its deployments.
 
-Instead of running Hydrate from the command line and entering flags and options manually, this extension will allow users to select a Kubernetes cluster and input options in VSCode.
+Instead of running Hydrate from the command line and entering flags and options manually, this extension allows users to select a Kubernetes cluster and run Hydrate within VSCode.
  
-## Test Out the Extension!
-First, make sure that you have the [VSCode Kubernetes Extension](https://github.com/Azure/vscode-kubernetes-tools) installed on VSCode and that you have cloned [Hydrate](https://github.com/microsoft/hydrate) into your home directory (currently, the extension uses the home directory as the default path to the Hydrate clone).
+## Install the Extension!
+First, make sure that you have cloned [Hydrate](https://github.com/microsoft/hydrate) into your home directory (currently, the extension uses the home directory as the default path to the Hydrate clone).
 
-Next, clone this repo, and open it in VSCode by running `code ./vscode-hydrate` from its parent directory. Once the window opens, press `F5` to open the Extension Development Host. 
+Next, download the extension [here](https://marketplace.visualstudio.com/items?itemName=madelineliao.vscode-hydrate). If you do not have the [VSCode Kubernetes Extension](https://github.com/Azure/vscode-kubernetes-tools) installed, it will automatically be installed during the Hydrate extension installation. A window reload is required after installation.
 
-A new window will open running the VSCode Hydrate extension. Click the Kubernetes extension icon in the sidebar, then right-click the cluster you would like to Hydrate and click `Hydrate Cluster`. The Hydrate output can be seen in the Debug Console in the original window, and a `component.yaml` file will be generated in your home directory!
+Navigate to the Kubernetes view by clicking the Kubernetes icon in the sidebar. Right-click the cluster you would like to run Hydrate on, and select `Hydrate Cluster`. A `component.yaml` file for the corresponding kubeconfig file will be generated in your home directory!
 
 Note: all clusters displayed in the sidebar are associated with the same `kubeconfig` file. To test out a different kubeconfig, click the "options" icon (the three dots) in the Kubernetes extension cluster explorer and click `Set Kubeconfig` to change the current `kubeconfig` file used. Then, you can run Hydrate on the newly displayed clusters with the new kubeconfig. 
 

--- a/package.json
+++ b/package.json
@@ -10,7 +10,7 @@
 		"url": "https://github.com/microsoft/vscode-hydrate.git"
 	},
 	"engines": {
-		"vscode": "^1.35.0"
+		"vscode": "^1.31.0"
 	},
 	"categories": [
 		"Other"


### PR DESCRIPTION
Closes #18 

The extension is now released on VSCode Marketplace [here](https://marketplace.visualstudio.com/items?itemName=madelineliao.vscode-hydrate)! The corresponding [Github release](https://github.com/microsoft/vscode-hydrate/releases/tag/v0.1.0) is published as well.

I added installation instructions to the README and changed the VSCode version dependency to `^1.31.0`. 