### PR TITLE
Merge with madelineliao/vscode-hydrate

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
 	"name": "vscode-hydrate",
-	"version": "1.0.0",
+	"version": "0.1.0",
 	"lockfileVersion": 1,
 	"requires": true,
 	"dependencies": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
 	"name": "vscode-hydrate",
-	"version": "0.1.0",
+	"version": "0.2.0",
 	"lockfileVersion": 1,
 	"requires": true,
 	"dependencies": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
 	"name": "vscode-hydrate",
-	"version": "0.2.0",
+	"version": "1.1.0",
 	"lockfileVersion": 1,
 	"requires": true,
 	"dependencies": {

--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
 	"description": "Hydrate for VSCode Kubernetes Tools",
 	"license": "MIT",
 	"publisher": "madelineliao",
-	"version": "0.2.0",
+	"version": "1.1.0",
 	"repository": {
 		"type": "git",
 		"url": "https://github.com/microsoft/vscode-hydrate.git"

--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
 	"description": "Hydrate for VSCode Kubernetes Tools",
 	"license": "MIT",
 	"publisher": "madelineliao",
-	"version": "1.0.0",
+	"version": "0.1.0",
 	"repository": {
 		"type": "git",
 		"url": "https://github.com/microsoft/vscode-hydrate.git"

--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
 	"description": "Hydrate for VSCode Kubernetes Tools",
 	"license": "MIT",
 	"publisher": "madelineliao",
-	"version": "0.1.0",
+	"version": "0.2.0",
 	"repository": {
 		"type": "git",
 		"url": "https://github.com/microsoft/vscode-hydrate.git"


### PR DESCRIPTION
I published the VSCode release via my fork instead of the upstream, so this merges the fork in. In the future, publishing will only be done via `microsoft/master` to avoid another merge like this one.

Since my first release was numbered `1.0.0`, I went with `1.1.0` for the next release (I had mistakenly labeled them `0.1.0` and `0.2.0` initially, which explains the first two commits. Still getting used to the VSCode release flow!