### PR TITLE
Added user input feature for Hydrate arguments

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,6 +14,11 @@ Navigate to the Kubernetes view by clicking the Kubernetes icon in the sidebar. 
 
 Note: all clusters displayed in the sidebar are associated with the same `kubeconfig` file. To test out a different kubeconfig, click the "options" icon (the three dots) in the Kubernetes extension cluster explorer and click `Set Kubeconfig` to change the current `kubeconfig` file used. Then, you can run Hydrate on the newly displayed clusters with the new kubeconfig. 
 
+![](https://thumbs.gfycat.com/DifficultPiercingIndianjackal-size_restricted.gif)
+
+For example, the results of running a verbose dry-run:
+
+![alt text](https://thumbs.gfycat.com/CreativeSpectacularHound-size_restricted.gif)
 ## Testing the Extension
 First, clone the repo locally by running the following command:
 ```

--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ First, make sure that you have cloned [Hydrate](https://github.com/microsoft/hyd
 
 Next, download the extension [here](https://marketplace.visualstudio.com/items?itemName=madelineliao.vscode-hydrate). If you do not have the [VSCode Kubernetes Extension](https://github.com/Azure/vscode-kubernetes-tools) installed, it will automatically be installed during the Hydrate extension installation. A window reload is required after installation.
 
-Navigate to the Kubernetes view by clicking the Kubernetes icon in the sidebar. Right-click the cluster you would like to run Hydrate on, and select `Hydrate Cluster`. A `component.yaml` file for the corresponding kubeconfig file will be generated in your home directory!
+Navigate to the Kubernetes view by clicking the Kubernetes icon in the sidebar. Right-click the cluster you would like to run Hydrate on, and select `Hydrate Cluster`. You will be prompted step-by-step through selecting options for Hydrate (e.g. output file path).
 
 Note: all clusters displayed in the sidebar are associated with the same `kubeconfig` file. To test out a different kubeconfig, click the "options" icon (the three dots) in the Kubernetes extension cluster explorer and click `Set Kubeconfig` to change the current `kubeconfig` file used. Then, you can run Hydrate on the newly displayed clusters with the new kubeconfig. 
 

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -1,8 +1,11 @@
 import * as vscode from 'vscode';
 import * as k8s from 'vscode-kubernetes-tools-api';
 
-import {existsSync} from 'fs';
-import {getKubeConfig} from './kubeconfig';
+import { existsSync } from 'fs';
+import { getKubeConfig } from './kubeconfig';
+import { MultiStepInput } from './multiStepInput';
+import { HydrateInput } from './hydrateInput';
+
 let kubectl: k8s.KubectlV1 | undefined = undefined;
 let clusterExplorer: k8s.ClusterExplorerV1 | undefined = undefined;
 
@@ -19,14 +22,14 @@ export async function activate (context: vscode.ExtensionContext) {
 	kubectl = kubectlAPI.api;
 	
 	const subscriptions = [
-		vscode.commands.registerCommand('vshydrate.hydrateCluster', hydrateCluster),
+		vscode.commands.registerCommand('vshydrate.hydrateCluster', hydrateCluster)
 	];
 
 	context.subscriptions.push(...subscriptions);
 }
 
 
-export function hydrateCluster () {
+export async function hydrateCluster () {
 	const kubeconfig = getKubeConfig();
 	let isErr = false;
 
@@ -35,10 +38,25 @@ export function hydrateCluster () {
 		return;
 	}
 
-	const term = vscode.window.createTerminal('hydrate');
-	term.show();
-	term.sendText(`cd && python3 -W ignore -m hydrate.hydrate -k ${kubeconfig} run`);
+
+	const input = new HydrateInput();
+	const inputEntered = await input.get();
+
+	if (inputEntered) {
+		const term = vscode.window.createTerminal('hydrate');
+		let termCommand = `cd && python3 -W ignore -m hydrate.hydrate -k ${kubeconfig}`;
+
+		input.args.forEach(function (arg) {
+			termCommand = termCommand.concat(arg);
+		});
+
+		termCommand = termCommand.concat(' run');
+		term.show();
+		term.sendText(termCommand);
+	}
 	
 }
+
+
 
 export function deactivate() {}

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -3,7 +3,6 @@ import * as k8s from 'vscode-kubernetes-tools-api';
 
 import { existsSync } from 'fs';
 import { getKubeConfig } from './kubeconfig';
-import { MultiStepInput } from './multiStepInput';
 import { HydrateInput } from './hydrateInput';
 
 let kubectl: k8s.KubectlV1 | undefined = undefined;

--- a/src/hydrateInput.ts
+++ b/src/hydrateInput.ts
@@ -1,0 +1,103 @@
+import { MultiStepInput } from "./multiStepInput";
+import * as vscode from 'vscode';
+
+export class HydrateInput {
+    readonly TITLE: string = 'Enter Hydrate Arguments';
+    readonly FLAGS: vscode.QuickPickItem[] = [
+        {label: 'Dry Run', description: '(only prints component.yaml to terminal)'},
+        {label: 'Verbose Mode', description: '(prints verbose output logs)'}];
+    readonly TOTAL_STEPS: number = 4;
+
+    componentName: string;
+    outputPath: string;
+    dryRun: boolean;
+    verbose: boolean;
+    args: string[];
+
+    constructor() {
+        this.componentName = '';
+        this.outputPath = '';
+        this.dryRun = false;
+        this.verbose = false;
+        this.args = [];
+    }
+
+    async get () {
+        if (!(await MultiStepInput.run(input => this.setComponentName(input)))) {
+            // command cancelled
+            return false;
+        }
+        return true;
+    }
+
+    async setComponentName(input: MultiStepInput) {
+        this.componentName = await input.showInputBox({
+            title: this.TITLE,
+            step: input.CurrentStepNumber,
+            totalSteps: this.TOTAL_STEPS,
+            prompt: 'What you want to name the component',
+            placeholder: 'default: hydratedCluster',
+            ignoreFocusOut: true,
+            value: (typeof this.componentName === 'string') ? this.componentName : '',
+            validate: async (value) => ''
+        });
+
+        if (this.componentName) {
+            this.args.push(` -n ${this.componentName}`);
+        }
+
+        return (input: MultiStepInput) => this.setOutputPath(input);
+    }
+
+    async setOutputPath (input: MultiStepInput) {
+        await input.showInputBox({
+            title: this.TITLE,
+            step: input.CurrentStepNumber,
+            totalSteps: this.TOTAL_STEPS,
+            prompt: 'In the next step, choose an output location for the component.yaml',
+            placeholder: 'Any input + ENTER to continue.',
+            ignoreFocusOut: true,
+            value: '',
+            validate: async (value) => ''
+        });
+
+        const file = await vscode.window.showOpenDialog({
+            canSelectFiles: false, 
+            canSelectFolders: true, 
+            canSelectMany: false,
+            defaultUri: (typeof this.outputPath === 'string') ? vscode.Uri.file(this.outputPath) : vscode.Uri.file('')
+        });
+
+        if (file) {
+            this.outputPath = file[0].fsPath;
+            this.args.push(` -o ${this.outputPath}`);
+        }
+
+        return (input: MultiStepInput) => this.setFlags(input);
+    }
+
+    async setFlags (input: MultiStepInput) {
+        const flags = await input.showQuickPick({
+            title: this.TITLE,
+            step: input.CurrentStepNumber,
+            items: this.FLAGS,
+            totalSteps: this.TOTAL_STEPS,
+            placeholder: 'Select output options',
+            canPickMany: true,
+            ignoreFocusOut: true,
+            convert: async (value: vscode.QuickPickItem) => value.label
+        });
+
+        if (flags) {
+            this.dryRun = flags.includes('Dry Run');
+            this.verbose = flags.includes('Verbose Mode');
+            if (this.dryRun) {
+                this.args.push(' -d');
+            }
+            if (this.verbose) {
+                this.args.push(' -v');
+            }
+        }
+
+    }
+}

--- a/src/multiStepInput.ts
+++ b/src/multiStepInput.ts
@@ -1,0 +1,230 @@
+// This code is originally from https://github.com/Borvik/vscode-postgres
+// License: https://github.com/Borvik/vscode-postgres/blob/master/LICENSE
+
+import { QuickPickItem, window, Disposable, CancellationToken, QuickInputButton, QuickInput, ExtensionContext, QuickInputButtons, Uri } from 'vscode';
+
+export type InputStep = (input: MultiStepInput) => Thenable<InputStep | void>;
+
+export class InputFlowAction {
+  private constructor() {}
+  static Back = new InputFlowAction();
+  static Cancel = new InputFlowAction();
+  static Resume = new InputFlowAction();
+}
+
+export interface MultiStepInputParameters {
+  title: string;
+  step: number;
+  totalSteps: number;
+  ignoreFocusOut?: boolean;
+  shouldResume?: () => Thenable<boolean>;
+  buttons?: QuickInputButton[];
+  placeholder?: string;
+}
+
+export interface InputBoxParameters extends MultiStepInputParameters {
+  value: string;
+  prompt: string;
+  password?: boolean;
+  validate: (value: string) => Promise<string | undefined>;
+  convert?: (value: string) => Promise<any>;
+}
+
+export interface QuickPickParameters<T extends QuickPickItem> extends MultiStepInputParameters {
+  matchOnDescription?: boolean;
+  matchOnDetail?: boolean;
+  canPickMany?: boolean;
+  items: T[];
+  activeItem?: T;
+  convert?: (value: T) => Promise<any>;
+}
+
+export class MultiStepInput {
+
+  private current?: QuickInput;
+  private steps: InputStep[] = [];
+  
+  static async run<T>(start: InputStep) {
+    const input = new MultiStepInput();
+    return input.stepThrough(start);
+  }
+
+  get CurrentStepNumber() { return this.steps.length; }
+
+  private async stepThrough<T>(start: InputStep): Promise<boolean> {
+    let step: InputStep | void = start;
+    let inputCompleted = true;
+    while (step) {
+      this.steps.push(step);
+      if (this.current) {
+        this.current.enabled = false;
+        this.current.busy = true;
+      }
+      try {
+        step = await step(this);
+      }
+      catch(err) {
+        if (err === InputFlowAction.Back) {
+          this.steps.pop();
+          step = this.steps.pop();
+        }
+        else if (err === InputFlowAction.Resume) {
+          step = this.steps.pop();
+        }
+        else if (err === InputFlowAction.Cancel) {
+          step = undefined;
+          inputCompleted = false;
+        }
+        else {
+          throw err;
+        }
+      }
+    }
+    if (this.current) {
+      this.current.dispose();
+    }
+    return inputCompleted;
+  }
+
+  redoLastStep() {
+    // const input = window.createInputBox();
+    // if (this.current) {
+    //   this.current.dispose();
+    // }
+    // this.current = input;
+    throw InputFlowAction.Back;
+  }
+
+  async showInputBox<P extends InputBoxParameters>({title, step, totalSteps, value, prompt, placeholder, ignoreFocusOut, password, validate, convert, buttons, shouldResume}: P) {
+    const disposables: Disposable[] = [];
+    try {
+      return await new Promise<any>((resolve, reject) => {
+        const input = window.createInputBox();
+        input.title = title;
+        input.step = step;
+        input.totalSteps = totalSteps;
+        input.value = value || '';
+        input.prompt = prompt;
+        input.placeholder = placeholder;
+        input.password = !!password;
+        input.ignoreFocusOut = !!ignoreFocusOut;
+        input.buttons = [
+          ...(this.steps.length > 1 ? [QuickInputButtons.Back] : []),
+          ...(buttons || [])
+        ];
+
+        let validating = validate('');
+        disposables.push(
+          input.onDidTriggerButton(item => {
+            if (item === QuickInputButtons.Back) {
+              reject(InputFlowAction.Back);
+            } else {
+              resolve(<any>item);
+            }
+          }),
+          input.onDidAccept(async () => {
+            const value = input.value;
+            input.enabled = false;
+            input.busy = true;
+            if (!(await validate(value))) {
+              if (convert) {
+                resolve(await convert(value));
+              } else {
+                resolve(value);
+              }
+            }
+            input.enabled = true;
+            input.busy = false;
+          }),
+          input.onDidChangeValue(async (text) => {
+            const current = validate(text);
+            validating = current;
+            const validationMessage = await current;
+            if (current === validating) {
+              input.validationMessage = validationMessage;
+            }
+          }),
+          input.onDidHide(async () => {
+            try {
+              reject(shouldResume && await shouldResume() ? InputFlowAction.Resume : InputFlowAction.Cancel);
+            }
+            catch(errorInShouldResume) {
+              reject(errorInShouldResume);
+            }
+          })
+        );
+
+        if (this.current) {
+          this.current.dispose();
+        }
+        this.current = input;
+        setTimeout(() => input.show(), 5);
+      });
+    }
+    finally {
+      disposables.forEach(d => d.dispose());
+    }
+  }
+
+  async showQuickPick<T extends QuickPickItem, P extends QuickPickParameters<T>>({title, step, totalSteps, items, activeItem, placeholder, ignoreFocusOut, matchOnDescription, matchOnDetail, canPickMany, convert, buttons, shouldResume}: P) {
+    const disposables: Disposable[] = [];
+    try {
+      return await new Promise<any>((resolve, reject) => {
+        const input = window.createQuickPick<T>();
+        input.title = title;
+        input.step = step;
+        input.totalSteps = totalSteps;
+        input.placeholder = placeholder;
+        input.ignoreFocusOut = !!ignoreFocusOut;
+        input.matchOnDescription = !!matchOnDescription;
+        input.matchOnDetail = !!matchOnDetail;
+        input.canSelectMany = !!canPickMany;
+        input.items = items;
+        if (activeItem) {
+          input.activeItems = [activeItem];
+        }
+        input.buttons = [
+          ...(this.steps.length > 1 ? [QuickInputButtons.Back] : []),
+					...(buttons || [])
+        ];
+        disposables.push(
+          input.onDidTriggerButton(item => {
+            if (item === QuickInputButtons.Back) {
+              reject(InputFlowAction.Back);
+            } else {
+              resolve(<any>item);
+            }
+          }),
+          input.onDidAccept(async () => {
+            if (!convert) {
+                convert = async (value: T) => value;
+            }
+            let convertedItems: any[] = await Promise.all(input.selectedItems.map(v => convert!(v)));
+            if (canPickMany) {
+              resolve(convertedItems);
+            } else {
+              resolve(convertedItems[0]);
+            }
+          }),
+          input.onDidHide(async () => {
+            try {
+              reject(shouldResume && await shouldResume() ? InputFlowAction.Resume : InputFlowAction.Cancel);
+            }
+            catch(errorInShouldResume) {
+              reject(errorInShouldResume);
+            }
+          })
+        );
+
+        if (this.current) {
+          this.current.dispose();
+        }
+        this.current = input;
+        setTimeout(() => input.show(), 5);
+      });
+    }
+    finally {
+      disposables.forEach(d => d.dispose());
+    }
+  }
+}

--- a/src/test/extension.test.ts
+++ b/src/test/extension.test.ts
@@ -29,14 +29,15 @@ suite('Test hydrateCluster', function () {
     suite('If kubeconfig is found and input is entered', function () {
         test('VSCode should create a terminal named \'hydrate\'', function () {
             sinon.stub(fs, 'existsSync').returns(true);
-            sinon.stub(HydrateInput.prototype, 'get').returns(Promise.resolve(true));
             const hydrateClusterSpy = sinon.spy(Extension, 'hydrateCluster');
             const createTerminal = sinon.spy(vscode.window, 'createTerminal');
 
-            hydrateClusterSpy();
-            assert(hydrateClusterSpy.calledOnce);
-            assert(createTerminal.called);
-            assert(vscode.window.terminals[0].name === 'hydrate');
+            hydrateClusterSpy().then(() => {
+                assert(hydrateClusterSpy.calledOnce);
+                assert(createTerminal.called);
+                assert(vscode.window.terminals[0].name === 'hydrate');
+            });
+            
         });
 
     });

--- a/src/test/extension.test.ts
+++ b/src/test/extension.test.ts
@@ -5,6 +5,7 @@ import * as KubeConfig from '../kubeconfig';
 import * as KubeHelpers from '../getKubeHelpers';
 import * as vscode from 'vscode';
 import * as fs from 'fs';
+import { HydrateInput } from '../hydrateInput';
 
 
 teardown(sinon.restore);
@@ -25,9 +26,10 @@ suite('Test hydrateCluster', function () {
         });
     });
 
-    suite('If kubeconfig is found', function () {
+    suite('If kubeconfig is found and input is entered', function () {
         test('VSCode should create a terminal named \'hydrate\'', function () {
             sinon.stub(fs, 'existsSync').returns(true);
+            sinon.stub(HydrateInput.prototype, 'get').returns(Promise.resolve(true));
             const hydrateClusterSpy = sinon.spy(Extension, 'hydrateCluster');
             const createTerminal = sinon.spy(vscode.window, 'createTerminal');
 


### PR DESCRIPTION
Closes #19 

The extension now guides the user through choosing options for Hydrate (component name, output file path, dry-run mode, verbose mode) through interactive prompts at the top of the VSCode window.

For the multistep input, I used the `multiStepInput.ts` from [this repo](https://github.com/Borvik/vscode-postgres) with some slight modifications.

![Multistep input](https://thumbs.gfycat.com/DifficultPiercingIndianjackal-size_restricted.gif)

 ![Dry run results](https://thumbs.gfycat.com/CreativeSpectacularHound-size_restricted.gif)