### PR TITLE
Only show Hydrate option for current context

### DIFF
--- a/package.json
+++ b/package.json
@@ -42,7 +42,8 @@
 			"view/item/context": [
 				{
 					"command": "vshydrate.hydrateCluster",
-					"when": "view == extension.vsKubernetesExplorer && viewItem =~ /vsKubernetes\\.\\w*cluster/i",
+					"when": "view == extension.vsKubernetesExplorer && viewItem =~ /vsKubernetes\\.\\w*cluster(?!.*\\.inactive$).*/i",
+					
 					"group": "hydrate"
 				}
 			]

--- a/package.json
+++ b/package.json
@@ -43,7 +43,6 @@
 				{
 					"command": "vshydrate.hydrateCluster",
 					"when": "view == extension.vsKubernetesExplorer && viewItem =~ /vsKubernetes\\.\\w*cluster(?!.*\\.inactive$).*/i",
-					
 					"group": "hydrate"
 				}
 			]


### PR DESCRIPTION
Closes #25 

Only displays "Hydrate Cluster" option when right-clicking the currently active cluster. The option isn't shown if the user right-clicks an inactive cluster. (This is because the kubeconfig reflects the current cluster only, so Hydrate can only be run on the currently active cluster).