### PR TITLE
Run Hydrate on Docker

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,9 +6,7 @@ This is the Visual Studio Code Hydrate extension, which builds upon the [VSCode 
 Instead of running Hydrate from the command line and entering flags and options manually, this extension allows users to select a Kubernetes cluster and run Hydrate within VSCode.
  
 ## Install the Extension!
-First, make sure that you have cloned [Hydrate](https://github.com/microsoft/hydrate) into your home directory (currently, the extension uses the home directory as the default path to the Hydrate clone).
-
-Next, download the extension [here](https://marketplace.visualstudio.com/items?itemName=madelineliao.vscode-hydrate). If you do not have the [VSCode Kubernetes Extension](https://github.com/Azure/vscode-kubernetes-tools) installed, it will automatically be installed during the Hydrate extension installation. A window reload is required after installation.
+First, make sure that you have [Docker](https://www.docker.com/) set up (the extension runs Hydrate on Docker). Next, download the extension [here](https://marketplace.visualstudio.com/items?itemName=madelineliao.vscode-hydrate). If you do not have the [VSCode Kubernetes Extension](https://github.com/Azure/vscode-kubernetes-tools) installed, it will automatically be installed during the Hydrate extension installation. A window reload is required after installation.
 
 Navigate to the Kubernetes view by clicking the Kubernetes icon in the sidebar. Right-click the cluster you would like to run Hydrate on, and select `Hydrate Cluster`. You will be prompted step-by-step through selecting options for Hydrate (e.g. output file path).
 

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -4,9 +4,7 @@ import * as k8s from 'vscode-kubernetes-tools-api';
 import { existsSync } from 'fs';
 import { getKubeConfig } from './kubeconfig';
 import { HydrateInput } from './hydrateInput';
-import { homedir } from 'os';
 
-const HOME = homedir;
 const IMAGE_NAME = 'mcr.microsoft.com/k8s/bedrock/hydrate:1.0';
 
 let kubectl: k8s.KubectlV1 | undefined = undefined;

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -4,6 +4,10 @@ import * as k8s from 'vscode-kubernetes-tools-api';
 import { existsSync } from 'fs';
 import { getKubeConfig } from './kubeconfig';
 import { HydrateInput } from './hydrateInput';
+import { homedir } from 'os';
+
+const HOME = homedir;
+const IMAGE_NAME = 'mcr.microsoft.com/k8s/bedrock/hydrate:1.0';
 
 let kubectl: k8s.KubectlV1 | undefined = undefined;
 let clusterExplorer: k8s.ClusterExplorerV1 | undefined = undefined;
@@ -43,15 +47,16 @@ export async function hydrateCluster () {
 
 	if (inputEntered) {
 		const term = vscode.window.createTerminal('hydrate');
-		let termCommand = `cd && python3 -W ignore -m hydrate.hydrate -k ${kubeconfig}`;
+		const dockerPull = `docker pull ${IMAGE_NAME}`;
+
+		let dockerRun = `docker run -v ${kubeconfig}:/config -v ${input.outputPath}:/app/out ${IMAGE_NAME} -k /config`;
 
 		input.args.forEach(function (arg) {
-			termCommand = termCommand.concat(arg);
+			dockerRun = dockerRun.concat(arg);
 		});
 
-		termCommand = termCommand.concat(' run');
 		term.show();
-		term.sendText(termCommand);
+		term.sendText(dockerRun);
 	}
 	
 }

--- a/src/hydrateInput.ts
+++ b/src/hydrateInput.ts
@@ -70,7 +70,6 @@ export class HydrateInput {
 
         if (file) {
             this.outputPath = file[0].fsPath;
-            this.args.push(` -o ${this.outputPath}`);
         }
 
         return (input: MultiStepInput) => this.setFlags(input);


### PR DESCRIPTION
Closes #32 

The extension now runs Hydrate on Docker, which eliminates the need for the user to clone the Hydrate repo and prevents Python environment errors.